### PR TITLE
Optimize PlantService database round trips

### DIFF
--- a/src/main/java/com/mintleaf/plant/PlantService.java
+++ b/src/main/java/com/mintleaf/plant/PlantService.java
@@ -47,7 +47,7 @@ public class PlantService {
 
     public void deletePlant(Long id) {
         Plant plant = this.plantRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("Plant with id " + " does not exist"));
+                .orElseThrow(() -> new EntityNotFoundException(String.format("Plant with id [%d] does not exist", id)));
         this.plantRepository.delete(plant);
     }
 


### PR DESCRIPTION
Issue: [https://github.com/zachhealy/mint-leaf/issues/11](https://github.com/zachhealy/mint-leaf/issues/11)

The PR optimizes PlantService by eliminating redundant database queries:
- updatePlant: Uses findById().map() instead of separate existsById() call
- deletePlant: Passes entity directly to delete(entity) instead of deleteById(id)

Reduces redundancy be reusing entity lookups